### PR TITLE
ol2/tt_top: Skip generating the top level .lef

### DIFF
--- a/ol2/tt_top/build.py
+++ b/ol2/tt_top/build.py
@@ -86,7 +86,6 @@ class TopFlow(SequentialFlow):
 		OpenROAD.STAPostPNR,
 		OpenROAD.IRDropReport,
 		Magic.StreamOut,
-		Magic.WriteLEF,
 		KLayout.StreamOut,
 		KLayout.XOR,
 		Checker.XOR,


### PR DESCRIPTION
Second part of TinyTapeout/tt-support-tools#48